### PR TITLE
Fix frequency bins misalignment

### DIFF
--- a/syncsweptsine.py
+++ b/syncsweptsine.py
@@ -368,6 +368,12 @@ class SyncSweep(object):
         self._update()
         return self._time
 
+    @property
+    def phi(self):
+        """Returns the sweep argument."""
+        self._update()
+        return self._phi
+
     def _update(self):
         """Updates the sweep if properties were changed."""
         if self._typed_property_was_changed:
@@ -413,6 +419,7 @@ class SyncSweep(object):
         self._duration = duration
         self._time = time
         self._signal = sweep
+        self._phi = phi
 
     def get_windowed_signal(self, left, right, pausestart=0, pausestop=0, amplitude=1):
         """Returns windowd sweep signal
@@ -649,7 +656,7 @@ class InvertedSyncSweepSpectrum(object):
         samplerate = self._samplerate
         sweepperiod = self._sweepperiod
         startfreq = self._startfreq
-        freq = _np.linspace(0, samplerate/2, int(_np.round(self.fftlen/2+1)))
+        freq = _np.fft.rfftfreq(self.fftlen, 1/samplerate)
         spectrum = _np.zeros_like(freq, dtype=_np.complex_)
         # eq. 43 definition of the inverse spectrum in frequency domain
         spectrum[1:] = (

--- a/syncsweptsine.py
+++ b/syncsweptsine.py
@@ -370,7 +370,7 @@ class SyncSweep(object):
 
     @property
     def phi(self):
-        """Returns the sweep argument."""
+        """Returns the instantaneous phase."""
         self._update()
         return self._phi
 

--- a/test_syncsweptsine.py
+++ b/test_syncsweptsine.py
@@ -150,12 +150,14 @@ def test_spectrum_to_minimum_phase():
     assume(np.allclose(np.unwrap(np.angle(H)), min_phase))
 
 def test_inverted_sync_sweep_spectrum():
-    FFTLEN = 1024
+    FFTLEN_EVEN = 1024
+    FFTLEN_ODD = 1025
+
     sweep = SyncSweep(10, 1000, 2, 2000)
-    ispec = InvertedSyncSweepSpectrum.from_sweep(sweep, fftlen=FFTLEN)
-    assume(ispec.fftlen == FFTLEN)
-    assume(len(ispec.freq) == (FFTLEN//2+1))
-    assume(len(ispec.spectrum) == (FFTLEN//2+1))
+    ispec = InvertedSyncSweepSpectrum.from_sweep(sweep, fftlen=FFTLEN_EVEN)
+    assume(ispec.fftlen == FFTLEN_EVEN)
+    assume(len(ispec.freq) == (FFTLEN_EVEN//2+1))
+    assume(len(ispec.spectrum) == (FFTLEN_EVEN//2+1))
     assume(ispec.spectrum[0] == 0j)
     expected_invspec = np.zeros_like(ispec.spectrum)
     expected_invspec[0] = 0j
@@ -167,15 +169,19 @@ def test_inverted_sync_sweep_spectrum():
         )
     assume(np.allclose(ispec.spectrum, expected_invspec))
 
-    ispec.fftlen = 2*FFTLEN
-    assume(ispec.fftlen == 2*FFTLEN)
-    assume(len(ispec.freq) == (2*FFTLEN//2+1))
-    assume(len(ispec.spectrum) == (2*FFTLEN//2+1))
+    ispec.fftlen = 2*FFTLEN_EVEN
+    assume(ispec.fftlen == 2*FFTLEN_EVEN)
+    assume(len(ispec.freq) == (2*FFTLEN_EVEN//2+1))
+    assume(len(ispec.spectrum) == (2*FFTLEN_EVEN//2+1))
     assume(len(ispec) == len(ispec.spectrum))
     assume(np.all(ispec.spectrum[::-1] == ispec[::-1]))
     assume(np.array(ispec, dtype='complex64').dtype == np.complex64)
     assume(ispec.__repr__().startswith('InvertedSyncSweepSpectrum('))
 
+    ispec.fftlen = FFTLEN_ODD
+    assume(ispec.fftlen == FFTLEN_ODD)
+    assume(len(ispec.freq) == ((FFTLEN_ODD+1)//2))
+    assume(len(ispec.spectrum) == ((FFTLEN_ODD+1)//2))
 
 def test_higher_harmonic_impulse_response():
     sweep = SyncSweep(10, 10000, 5, 20000)


### PR DESCRIPTION
- frequency bins for inverted sweep spectrum in `InvertedSyncSweepSpectrum.from_sweep` method were different from frequency bins for measured sweep spectrum in `HigherHarmonicImpulseResponse.from_sweeps` method;
- these frequency bins should be in perfect alignment since we multiply measured sweep spectrum `rspec` and inverted sweep spectrum `rinvspec` in `HigherHarmonicImpulseResponse.from_spectra` method;
- added test for odd FFT length `FFTLEN_ODD = 1025` in `test_inverted_sync_sweep_spectrum`;
- this test fails on `master` branch and passes on `fix_freq` branch;
- added read-only property for sweep argument in `SyncSweep` class;
- this property is useful for simulating nonlinear processing with predefined harmonics.